### PR TITLE
Show the HTTP status code in the error

### DIFF
--- a/Nyaa.py
+++ b/Nyaa.py
@@ -13,7 +13,7 @@ class Nyaa(object):
 	def last_entry(self):
 		r = requests.get(self.url)
 		if r.status_code not in range(100, 399):
-			print('Fetching error, nyaa may have blocked your IP or be down (HTTP %s)' % r.status_code, file=sys.stderr)
+			print('Fetching error, nyaa may have blocked your IP or be down (HTTP {})'.format(r.status_code), file=sys.stderr)
 			sys.exit(1)
 
 		soup = BeautifulSoup(r.text)

--- a/Nyaa.py
+++ b/Nyaa.py
@@ -13,7 +13,7 @@ class Nyaa(object):
 	def last_entry(self):
 		r = requests.get(self.url)
 		if r.status_code not in range(100, 399):
-			print('Fetching error, nyaa may have blocked your IP or be down', file=sys.stderr)
+			print('Fetching error, nyaa may have blocked your IP or be down (HTTP %s)' % r.status_code, file=sys.stderr)
 			sys.exit(1)
 
 		soup = BeautifulSoup(r.text)


### PR DESCRIPTION
Wanted to include this in 2e8e85c, but the code was always `None` and I didn't know why (sorry for not noticing that wasn't the `Request` object).
