### PR TITLE
Retry on random connection errors

### DIFF
--- a/Nyaa.py
+++ b/Nyaa.py
@@ -3,15 +3,17 @@ import re
 import requests
 import sys
 
-def retry_if_fails(r):
-	if r.status_code not in range(100, 399):
-		print('Connection error, retrying... (HTTP {})'.format(r.status_code), file=sys.stderr)
-		return retry_if_fails(r)
+def retry_if_fails(req, *args, **kwargs):
 	try:
-		return r
-	except(requests.exceptions.ConnectionError, requests.packages.urllib3.exceptions.ProtocolError) as e:
+		r = req(*args, **kwargs)
+		if r.status_code not in range(100, 399):
+			print('Connection error, retrying... (HTTP {})'.format(r.status_code), file=sys.stderr)
+			return retry_if_fails(req, *args, **kwargs)
+		else:
+			return r
+	except requests.exceptions.ConnectionError as e:
 		print('Connection error, retrying... ({})'.format(e.args[0].args[1]), file=sys.stderr)
-		return retry_if_fails(r)
+		return retry_if_fails(req, *args, **kwargs)
 
 class Nyaa(object):
 	def __init__(self, url):
@@ -35,7 +37,7 @@ class NyaaEntry(object):
 		self.info_url = '{}{}'.format(nyaa.info_url, nyaa_id)
 		self.download_url = '{}{}&magnet=1'.format(nyaa.dl_url, nyaa_id)
 
-		r = retry_if_fails(requests.get(self.info_url))
+		r = retry_if_fails(requests.get, self.info_url)
 		setattr(r, 'encoding', 'utf-8')
 		self.page = BeautifulSoup(r.text)
 		if self.page.find('div', class_='content').text == '\xa0The torrent you are looking for does not appear to be in the database.':
@@ -73,7 +75,7 @@ class NyaaEntry(object):
 
 	@property
 	def hash(self):
-		r = retry_if_fails(requests.head(self.download_url))
+		r = retry_if_fails(requests.head, self.download_url)
 		if 'Location' in r.headers:
 			return re.search(r'magnet:\?xt=urn:btih:(.*)&tr=', r.headers['Location']).group(1).upper()
 		else:

--- a/Nyaa.py
+++ b/Nyaa.py
@@ -3,17 +3,17 @@ import re
 import requests
 import sys
 
-def retry_if_fails(req, *args, **kwargs):
+def _retry_on_fail(req, *args, **kwargs):
 	try:
 		r = req(*args, **kwargs)
 		if r.status_code not in range(100, 399):
 			print('Connection error, retrying... (HTTP {})'.format(r.status_code), file=sys.stderr)
-			return retry_if_fails(req, *args, **kwargs)
+			return _retry_on_fail(req, *args, **kwargs)
 		else:
 			return r
 	except requests.exceptions.ConnectionError as e:
 		print('Connection error, retrying... ({})'.format(e.args[0].args[1]), file=sys.stderr)
-		return retry_if_fails(req, *args, **kwargs)
+		return _retry_on_fail(req, *args, **kwargs)
 
 class Nyaa(object):
 	def __init__(self, url):
@@ -37,7 +37,7 @@ class NyaaEntry(object):
 		self.info_url = '{}{}'.format(nyaa.info_url, nyaa_id)
 		self.download_url = '{}{}&magnet=1'.format(nyaa.dl_url, nyaa_id)
 
-		r = retry_if_fails(requests.get, self.info_url)
+		r = _retry_on_fail(requests.get, self.info_url)
 		setattr(r, 'encoding', 'utf-8')
 		self.page = BeautifulSoup(r.text)
 		if self.page.find('div', class_='content').text == '\xa0The torrent you are looking for does not appear to be in the database.':
@@ -75,7 +75,7 @@ class NyaaEntry(object):
 
 	@property
 	def hash(self):
-		r = retry_if_fails(requests.head, self.download_url)
+		r = _retry_on_fail(requests.head, self.download_url)
 		if 'Location' in r.headers:
 			return re.search(r'magnet:\?xt=urn:btih:(.*)&tr=', r.headers['Location']).group(1).upper()
 		else:

--- a/Nyaa.py
+++ b/Nyaa.py
@@ -25,7 +25,14 @@ class NyaaEntry(object):
 		self.info_url = '{}{}'.format(nyaa.info_url, nyaa_id)
 		self.download_url = '{}{}&magnet=1'.format(nyaa.dl_url, nyaa_id)
 
-		r = requests.get(self.info_url)
+		try:
+			r = requests.get(self.info_url)
+			if r.status_code not in range(100, 399):
+				print('Connection error, retrying... (HTTP {})'.format(e), file=sys.stderr)
+		except (requests.exceptions.ConnectionError, requests.packages.urllib3.exceptions.ProtocolError) as e:
+			print('Connection error, retrying... ({})'.format(e.args[0].args[1]), file=sys.stderr)
+			r = requests.get(self.info_url)
+
 		setattr(r, 'encoding', 'utf-8')
 		self.page = BeautifulSoup(r.text)
 		if self.page.find('div', class_='content').text == '\xa0The torrent you are looking for does not appear to be in the database.':
@@ -63,7 +70,11 @@ class NyaaEntry(object):
 
 	@property
 	def hash(self):
-		r = requests.head(self.download_url)
+		try:
+			r = requests.head(self.download_url)
+		except (requests.exceptions.ConnectionError, requests.packages.urllib3.exceptions.ProtocolError) as e:
+			print('Connection error, retrying... ({})'.format(e.args[0].args[1]), file=sys.stderr)
+			r = requests.head(self.download_url)
 		if 'Location' in r.headers:
 			return re.search(r'magnet:\?xt=urn:btih:(.*)&tr=', r.headers['Location']).group(1).upper()
 		else:


### PR DESCRIPTION
Prevents the scraper from completely stopping when a connection error (during the scraping, not initially) occurs.
